### PR TITLE
feat: HashiCorp Vault 연동 (AppRole, KV v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Local secrets ###
+.envrc

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
+ext {
+    set('springCloudVersion', '2025.0.0')
+}
+
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
 description = 'backend'
@@ -18,7 +22,14 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
 dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-vault-config'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -4,28 +4,28 @@
 
 ## 0. 사전 확인
 
-- [ ] 로컬 도구 버전 확인 (Java 17, Docker, kubectl, gh CLI)
+- [x] 로컬 도구 버전 확인 (Java 17, Docker, kubectl, gh CLI)
 - [ ] Synology NAS 내 의존 서비스 상태 확인 (Vault, Keycloak, MariaDB)
 - [ ] GitHub 프로젝트/마일스톤/이슈 접근 확인
 
-## 1. M1 우선 진행
+## 1. M1 완료
 
-- [ ] `#1` Backend bootstrap
-- [ ] `#2` Frontend scaffold
-- [ ] `#3` dev/prod config convention
-
-완료 조건:
-- [ ] WSL/Mac 모두에서 기동 문서 기준 실행 가능
-- [ ] `dev/prod` 설정 분리 확인
+- [x] `#1` Backend bootstrap
+- [x] `#2` Frontend scaffold
+- [x] `#3` dev/prod config convention
 
 ## 2. M2 진행
 
 - [ ] `#4` MariaDB + migration baseline
-- [ ] `#5` Vault secret integration
+- [x] `#5` Vault secret integration
 
 완료 조건:
-- [ ] Vault 기반 DB 연결 성공
+- [x] Vault 기반 DB 연결 성공
 - [ ] 초기 스키마 자동 마이그레이션 성공
+
+### M2 다음 작업
+
+- [ ] `#4` Flyway 또는 Liquibase로 초기 스키마 마이그레이션 구성
 
 ## 3. M3 진행
 
@@ -47,10 +47,15 @@
 
 ## 5. 다음 세션 시작 명령
 
-아래 순서로 시작:
+```bash
+# NAS 서비스 상태 확인 후
+./gradlew bootRun   # dev 프로파일 자동 적용 (direnv)
+```
 
-1. `gh issue view 1 --repo Hun-Jeon/backend`
-2. `gh issue view 2 --repo Hun-Jeon/backend`
-3. `gh issue view 3 --repo Hun-Jeon/backend`
-4. M1 범위 코드 작업 착수
+## 환경 설정 참고
 
+- Java 17 (Temurin): `/Library/Java/JavaVirtualMachines/temurin-17.jdk`
+- 로컬 dev 환경변수: `.envrc` (direnv, gitignore됨)
+  - `VAULT_ROLE_ID`, `VAULT_SECRET_ID`, `SPRING_PROFILES_ACTIVE=dev`
+- Vault: `https://vault.hjeon.i234.me` / KV v2 / AppRole 인증
+- DB: `jdbc:mysql://192.168.0.39:33306/backend` (username/password는 Vault 주입)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+  cloud:
+    vault:
+      authentication: APPROLE
+      app-role:
+        role-id: ${VAULT_ROLE_ID}
+        secret-id: ${VAULT_SECRET_ID}
+  config:
+    import: "vault://kv/backend/dev/db"
+  datasource:
+    url: jdbc:mysql://192.168.0.39:33306/backend
+    username: ${db.username}
+    password: ${db.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  cloud:
+    vault:
+      authentication: APPROLE
+      app-role:
+        role-id: ${VAULT_ROLE_ID}
+        secret-id: ${VAULT_SECRET_ID}
+  config:
+    import: "vault://kv/backend/prod/db"
+  datasource:
+    url: jdbc:mysql://192.168.0.39:33306/backend
+    username: ${db.username}
+    password: ${db.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  application:
+    name: backend
+  cloud:
+    vault:
+      uri: https://vault.hjeon.i234.me
+      fail-fast: true
+      kv:
+        enabled: true
+        backend: kv


### PR DESCRIPTION
## Summary

- Spring Cloud Vault (`2025.0.0`) 추가로 Vault KV v2 연동 구성
- AppRole 인증 방식 적용 (dev/prod 공통), 자격증명은 환경변수(`VAULT_ROLE_ID`, `VAULT_SECRET_ID`)로 주입
- `application.properties` → `application.yml` 전환 및 dev/prod 프로파일 분리
- Vault 경로 `kv/backend/{profile}/db` 에서 `db.username`, `db.password` 읽어 datasource에 주입
- `.envrc` gitignore 추가 (direnv 기반 로컬 시크릿 관리)

Closes #5

## Test plan

- [x] `VAULT_ROLE_ID` / `VAULT_SECRET_ID` 환경변수 설정 후 `./gradlew bootRun` 실행
- [x] Vault AppRole 인증 성공 확인
- [x] `kv/backend/dev/db` 에서 DB 자격증명 주입 확인
- [x] `HikariPool-1 - Start completed` — DB 연결 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)